### PR TITLE
use /usr/bin/env to find python2.4

### DIFF
--- a/Products/RhaptosPrint/printing/course_print.mak
+++ b/Products/RhaptosPrint/printing/course_print.mak
@@ -7,7 +7,7 @@
 # This software is subject to the provisions of the GNU Lesser General
 # Public License Version 2.1 (LGPL).  See LICENSE.txt for details.
 #
-PYTHON = /usr/bin/python2.4
+PYTHON = /usr/bin/env python2.4
 PRINT_DIR = /opt/printing
 HOST = http://localhost:8080
 VERSION = latest

--- a/Products/RhaptosPrint/printing/module_print.mak
+++ b/Products/RhaptosPrint/printing/module_print.mak
@@ -7,7 +7,7 @@
 # This software is subject to the provisions of the GNU Lesser General
 # Public License Version 2.1 (LGPL).  See LICENSE.txt for details.
 #
-PYTHON = /usr/bin/python2.4
+PYTHON = /usr/bin/env python2.4
 PRINT_DIR = /opt/printing
 HOST = http://localhost:8080
 VERSION = latest


### PR DESCRIPTION
this will allow printing via legacy deployed from cnx-deploy to find the python2.4 installed under /usr/local/bin.