### PR TITLE
Add oer.exports requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,14 @@ setup(name='Products.RhaptosPrint',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
+          'lxml',
+          'argparse',
+          'pillow',
+          'numpy',
+          'wand',
+          'python-memcached',
+          'jinja2==2.6',
+          'demjson==1.6'
           'setuptools',
       ],
       tests_require = [


### PR DESCRIPTION
This adds the oer.exports requirements to its parent package. This resolves a deployment issue where the requirements would otherwise be missing.