### PR TITLE
Avoid writing same filenames in different directories

### DIFF
--- a/Products/RhaptosPrint/RhaptosPrintTool.py
+++ b/Products/RhaptosPrint/RhaptosPrintTool.py
@@ -98,11 +98,11 @@ class RhaptosPrintTool(UniqueObject, SimpleItem):
             data - the print file to store
         """
         #Grab the file to update, else create a new one.
+        fileName = self._createFileName(objectId, version, type)
         if container is None:
-            container = self._getContainer()
+            container = self._getContainer(fileName)
         if hasattr(container, '_write_file'): # It's some flavor of localFS
             # Hey, we're a localFS folder, do it directly
-            fileName = self._createFileName(objectId, version, type)
             container._write_file(data, container._getpath(fileName))
 
         else: # Do the plone/object dance
@@ -162,9 +162,9 @@ class RhaptosPrintTool(UniqueObject, SimpleItem):
             version - the module or collection version
             filetype - file type: pdf or zip
         """
-        if container is None:
-            container = self._getContainer()
         fileName = self._createFileName(objectId, version, filetype)
+        if container is None:
+            container = self._getContainer(fileName)
         if getattr(container, fileName, None):
             container.manage_delObjects([fileName])
         if self.print_file_status.has_key(fileName):
@@ -273,8 +273,17 @@ class RhaptosPrintTool(UniqueObject, SimpleItem):
                 containers.append(container)
         return containers
 
-    def _getContainer(self):
-        return self._getContainers()[0]
+    def _getContainer(self, filename=None):
+        """
+        Look in all containers for filename if filename is not None.  Return
+        the container that contains that file or return the first container.
+        """
+        containers = self._getContainers()
+        if filename:
+            for container in containers:
+                if hasattr(container, filename):
+                    return container
+        return containers[0]
 
     ## Print config methods, formerly of RhaptosCollection.AsyncPrint ##
 


### PR DESCRIPTION
Right now, when we have a new collection minor version, a new pdf is
created with the same name in the first "storage" in the rhaptos print
tool.  We sometimes end up having multiple files with the same name
because legacy doesn't use collection minor versions.

The way to fix this is by looking for the existing file and overwriting
the original file.

Change RhaptosPrintTool._getContainer to look in all containers for the
filename and return the container if found, otherwise return the first
container.